### PR TITLE
Center Slideshow Images in Player

### DIFF
--- a/src/components/Medias/Channels/Slideshow.js
+++ b/src/components/Medias/Channels/Slideshow.js
@@ -170,7 +170,7 @@ class Slideshow extends Component {
     adaptImageToHeight = (width, height) => {
         let imgWidth = this.props.imageDisplayed.element.width;
         let imgHeight = this.props.imageDisplayed.element.height;
-        let margin = (width - imgWidth / imgHeight * height) / 2;
+        let margin = ((width - imgWidth) / (imgHeight * height)) / 2;
         return {
             marginLeft: margin + "px",
             height: "100%",


### PR DESCRIPTION
When using the player to display a slideshow, the images are not always centred. This is due to a simple bug in `react-web-media-player/lib/components/Medias/Channels/Slideshow.js` L173:

```
var margin = (height - imgHeight / imgWidth * width) / 2;
```

The lack of parentheses around the `height - imgHeight` & `imgWidth * width` calculations results in erroneous calculations for the `leftMargin` CSS property. 

Fixes #12 